### PR TITLE
Add restoration of `unit_system` state

### DIFF
--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -230,6 +230,8 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
 
             if code == 200 and unit_system:
                 updated_data[f"{key}:unit_system"] = unit_system
+            else:
+                updated_data.pop(f"{key}:unit_system", None)
 
             if code not in (200, 404):
                 _LOGGER.warning(


### PR DESCRIPTION
This was not done before, so if the API returned imperial data, this would not be converted correctly after a restart.

This also ensures that the data is cleared out when the header is absent in later requests (which is unlikely).

It also looks up the `unit_system` from the `value_key_path`, ensuring that the unit system is used for all sensors that the data applies to.