### PR TITLE
New entity attributes: age & fetched at

### DIFF
--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -230,6 +230,8 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
 
             if code == 200 and unit_system:
                 updated_data[f"{key}:unit_system"] = unit_system
+            else:
+                updated_data.pop(f"{key}:unit_system", None)
 
             if code not in (200, 404):
                 _LOGGER.warning(

--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
 )
+from homeassistant.util import dt as dt_util
 
 from .auth import AbstractAuth
 from .const import DOMAIN
@@ -225,6 +226,8 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
             body = item["body"]
             headers = item.get("headers") or {}
             unit_system = headers.get("sc-unit-system")
+            data_age = headers.get("sc-data-age")
+            fetched_at = headers.get("sc-fetched-at")
             key = path.strip("/").replace("/", "_")
             updated_data[key] = body if code == 200 else None
 
@@ -232,6 +235,16 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
                 updated_data[f"{key}:unit_system"] = unit_system
             else:
                 updated_data.pop(f"{key}:unit_system", None)
+
+            if code == 200 and data_age:
+                updated_data[f"{key}:data_age"] = dt_util.parse_datetime(data_age)
+            else:
+                updated_data.pop(f"{key}:data_age", None)
+
+            if code == 200 and fetched_at:
+                updated_data[f"{key}:fetched_at"] = dt_util.parse_datetime(fetched_at)
+            else:
+                updated_data.pop(f"{key}:fetched_at", None)
 
             if code not in (200, 404):
                 _LOGGER.warning(

--- a/custom_components/smartcar/entity.py
+++ b/custom_components/smartcar/entity.py
@@ -40,6 +40,18 @@ class SmartcarEntity(CoordinatorEntity[SmartcarVehicleCoordinator], RestoreEntit
     def available(self):
         return super().available and self._extract_value() is not None
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        result = {}
+
+        if data_age := self._extract_data_age():
+            result["age"] = data_age.isoformat()
+
+        if fetched_at := self._extract_fetched_at():
+            result["fetched_at"] = fetched_at.isoformat()
+
+        return result or None
+
     async def async_update(self) -> None:
         if not self.enabled:
             return
@@ -70,6 +82,12 @@ class SmartcarEntity(CoordinatorEntity[SmartcarVehicleCoordinator], RestoreEntit
         if unit_system := self._extract_unit_system():
             data["unit_system"] = unit_system
 
+        if data_age := self._extract_data_age():
+            data["data_age"] = data_age
+
+        if fetched_at := self._extract_fetched_at():
+            data["fetched_at"] = fetched_at
+
         return RestoredExtraData(data)
 
     def _extract_unit_system(self) -> Any:
@@ -77,6 +95,18 @@ class SmartcarEntity(CoordinatorEntity[SmartcarVehicleCoordinator], RestoreEntit
         description = self.entity_description
         key_path = description.value_key_path.split(".")
         return data.get(f"{key_path[0]}:unit_system")
+
+    def _extract_data_age(self) -> Any:
+        data = self.coordinator.data or {}
+        description = self.entity_description
+        key_path = description.value_key_path.split(".")
+        return data.get(f"{key_path[0]}:data_age")
+
+    def _extract_fetched_at(self) -> Any:
+        data = self.coordinator.data or {}
+        description = self.entity_description
+        key_path = description.value_key_path.split(".")
+        return data.get(f"{key_path[0]}:fetched_at")
 
     def _extract_raw_value(self) -> Any:
         data = self.coordinator.data or {}
@@ -119,6 +149,12 @@ class SmartcarEntity(CoordinatorEntity[SmartcarVehicleCoordinator], RestoreEntit
 
         if unit_system := extra_data.get("unit_system"):
             data[f"{key_path[0]}:unit_system"] = unit_system
+
+        if data_age := extra_data.get("data_age"):
+            data[f"{key_path[0]}:data_age"] = data_age
+
+        if fetched_at := extra_data.get("fetched_at"):
+            data[f"{key_path[0]}:fetched_at"] = fetched_at
 
     async def _async_send_command(
         self, subpath, payload, *, method="post", version="2.0", **kwargs

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -141,7 +141,9 @@
 # name: test_limited_scopes[enabled_scopes0-vw_id_4][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
       'device_class': 'battery',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
       'friendly_name': 'VW ID.4 Battery',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
@@ -157,7 +159,9 @@
 # name: test_limited_scopes[enabled_scopes0-vw_id_4][sensor.vw_id_4_battery_capacity]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T17:27:25.114000+00:00',
       'device_class': 'energy_storage',
+      'fetched_at': '2025-05-09T17:27:25.114000+00:00',
       'friendly_name': 'VW ID.4 Battery Capacity',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -173,7 +177,9 @@
 # name: test_limited_scopes[enabled_scopes0-vw_id_4][sensor.vw_id_4_range]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
       'device_class': 'distance',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
       'friendly_name': 'VW ID.4 Range',
       'icon': 'mdi:map-marker-distance',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -333,6 +339,7 @@
 # name: test_standard_setup[unknown_make][device_tracker.smartcar_784n_location]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
       'friendly_name': 'Smartcar 784N Location',
       'gps_accuracy': 0,
       'icon': 'mdi:car',
@@ -1027,6 +1034,7 @@
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_odometer]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
       'device_class': 'distance',
       'friendly_name': 'Smartcar 784N Odometer',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
@@ -1060,6 +1068,7 @@
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_tire_pressure_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
       'device_class': 'pressure',
       'friendly_name': 'Smartcar 784N Tire Pressure Back Left',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1076,6 +1085,7 @@
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_tire_pressure_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
       'device_class': 'pressure',
       'friendly_name': 'Smartcar 784N Tire Pressure Back Right',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1092,6 +1102,7 @@
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_tire_pressure_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
       'device_class': 'pressure',
       'friendly_name': 'Smartcar 784N Tire Pressure Front Left',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1108,6 +1119,7 @@
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_tire_pressure_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
       'device_class': 'pressure',
       'friendly_name': 'Smartcar 784N Tire Pressure Front Right',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1138,7 +1150,9 @@
 # name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
       'device_class': 'plug',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
       'friendly_name': 'VW ID.4 Charging Cable Plugged In',
     }),
     'context': <ANY>,
@@ -1185,6 +1199,8 @@
 # name: test_standard_setup[vw_id_4][device_tracker.vw_id_4_location]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:52+00:00',
+      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
       'friendly_name': 'VW ID.4 Location',
       'gps_accuracy': 0,
       'icon': 'mdi:car',
@@ -1782,6 +1798,8 @@
 # name: test_standard_setup[vw_id_4][number.vw_id_4_charge_limit]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:55+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
       'friendly_name': 'VW ID.4 Charge Limit',
       'icon': 'mdi:battery-charging-80',
       'max': 100.0,
@@ -1801,7 +1819,9 @@
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
       'device_class': 'battery',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
       'friendly_name': 'VW ID.4 Battery',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
@@ -1817,7 +1837,9 @@
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_battery_capacity]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T17:27:25.114000+00:00',
       'device_class': 'energy_storage',
+      'fetched_at': '2025-05-09T17:27:25.114000+00:00',
       'friendly_name': 'VW ID.4 Battery Capacity',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
@@ -1833,6 +1855,8 @@
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
       'friendly_name': 'VW ID.4 Charging Status',
       'icon': 'mdi:ev-station',
     }),
@@ -1879,7 +1903,9 @@
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_odometer]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:52+00:00',
       'device_class': 'distance',
+      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
       'friendly_name': 'VW ID.4 Odometer',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
@@ -1895,7 +1921,9 @@
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_range]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
       'device_class': 'distance',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
       'friendly_name': 'VW ID.4 Range',
       'icon': 'mdi:map-marker-distance',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -1976,6 +2004,8 @@
 # name: test_standard_setup[vw_id_4][switch.vw_id_4_charging]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
       'friendly_name': 'VW ID.4 Charging',
       'icon': 'mdi:ev-plug-type2',
     }),

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -57,7 +57,9 @@
 # name: test_limited_scopes[enabled_scopes0-vw_id_4][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
       'device_class': 'battery',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
       'friendly_name': 'VW ID.4 Battery',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
@@ -224,7 +226,9 @@
 # name: test_polling_updates[vw_id_4][sensor.vw_id_4_odometer]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:52+00:00',
       'device_class': 'distance',
+      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
       'friendly_name': 'VW ID.4 Odometer',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
@@ -332,6 +336,7 @@
 # name: test_unit_conversion[imperial-vw_id_4][sensor.vw_id_4_odometer]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
       'device_class': 'distance',
       'friendly_name': 'VW ID.4 Odometer',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -247,8 +247,22 @@ async def test_unit_conversion(
             "72.7423488",
             {"battery": {"range": 45.2}, "battery:unit_system": "imperial"},
         ),
+        (
+            "sensor.vw_id_4_range",
+            {
+                "raw_value": 45.2,
+                "data_age": dt.datetime(2025, 5, 29, 19, 47, 32),
+                "fetched_at": dt.datetime(2025, 5, 29, 20, 9, 57),
+            },
+            "45.2",
+            {
+                "battery": {"range": 45.2},
+                "battery:data_age": dt.datetime(2025, 5, 29, 19, 47, 32),
+                "battery:fetched_at": dt.datetime(2025, 5, 29, 20, 9, 57),
+            },
+        ),
     ],
-    ids=["value_only", "value_and_unit_system"],
+    ids=["value_only", "value_and_unit_system", "value_and_timestampes"],
 )
 @pytest.mark.parametrize("vehicle_fixture", ["vw_id_4"])
 async def test_restore_state(


### PR DESCRIPTION
This will work for any API response that returns the `sc-data-age` and`sc-fetched-at` headers.

Resolves: #17.

This includes #18.