### PR TITLE
feat: add fuel percentage and range sensors

### DIFF
--- a/custom_components/smartcar/const.py
+++ b/custom_components/smartcar/const.py
@@ -67,6 +67,8 @@ class EntityDescriptionKey(StrEnum):
     CHARGING_STATE = auto()
     ENGINE_OIL = auto()
     FUEL = auto()
+    FUEL_PERCENT = auto()
+    FUEL_RANGE = auto()
     ODOMETER = auto()
     RANGE = auto()
     TIRE_PRESSURE_BACK_LEFT = auto()

--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -49,6 +49,8 @@ ENTITY_CONFIG_MAP = {
     ),
     EntityDescriptionKey.ENGINE_OIL: EntityConfig("/engine/oil", ["read_engine_oil"]),
     EntityDescriptionKey.FUEL: EntityConfig("/fuel", ["read_fuel"]),
+    EntityDescriptionKey.FUEL_PERCENT: EntityConfig("/fuel", ["read_fuel"]),
+    EntityDescriptionKey.FUEL_RANGE: EntityConfig("/fuel", ["read_fuel"]),
     EntityDescriptionKey.LOCATION: EntityConfig("/location", ["read_location"]),
     EntityDescriptionKey.ODOMETER: EntityConfig("/odometer", ["read_odometer"]),
     EntityDescriptionKey.PLUG_STATUS: EntityConfig("/charge", ["read_charge"]),

--- a/custom_components/smartcar/sensor.py
+++ b/custom_components/smartcar/sensor.py
@@ -78,6 +78,27 @@ SENSOR_TYPES: tuple[SmartcarSensorDescription, ...] = (
         ),
     ),
     SmartcarSensorDescription(
+        key=EntityDescriptionKey.FUEL_PERCENT,
+        name="Fuel Percent",
+        value_key_path="fuel.percentRemaining",
+        value_cast=lambda pct: pct and round(pct * 100),
+        icon="mdi:gas-station",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.FUEL_RANGE,
+        name="Fuel Range",
+        value_key_path="fuel.range",
+        icon="mdi:map-marker-distance",
+        device_class=SensorDeviceClass.DISTANCE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfLength.KILOMETERS,
+        imperial_conversion=lambda v: DistanceConverter.convert(
+            v, UnitOfLength.MILES, UnitOfLength.KILOMETERS
+        ),
+    ),
+    SmartcarSensorDescription(
         key=EntityDescriptionKey.ODOMETER,
         name="Odometer",
         value_key_path="odometer.distance",


### PR DESCRIPTION
- Add FUEL_PERCENT and FUEL_RANGE entity keys to const.py
- Add entity configurations for new fuel sensors in coordinator.py
- Add SmartcarSensorDescription for fuel percentage and range in sensor.py
- Fuel percentage sensor converts percentRemaining (0-1) to percentage (0-100%)
- Fuel range sensor uses fuel.range with distance device class and km/mi conversion
- All three fuel sensors (amount, percent, range) use same /fuel endpoint
- Maintains backward compatibility with existing fuel sensor
- Addresses issue where amountRemaining is often null but percentRemaining and range are available

This allows Home Assistant users to see comprehensive fuel information:
- sensor.vehicle_fuel (litres, may be unavailable)
- sensor.vehicle_fuel_percent (always populated if Smartcar returns percentRemaining)
- sensor.vehicle_fuel_range (populated if range is returned)