### PR TITLE
Fix location restore state

### DIFF
--- a/custom_components/smartcar/entity.py
+++ b/custom_components/smartcar/entity.py
@@ -47,7 +47,7 @@ class SmartcarEntity[ValueT, RawValueT](
 
     @property
     def available(self) -> bool:
-        return super().available and self._extract_value() is not None
+        return super().available and self._extract_raw_value() is not None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:

--- a/tests/snapshots/test_device_tracker.ambr
+++ b/tests/snapshots/test_device_tracker.ambr
@@ -1,0 +1,11 @@
+# serializer version: 1
+# name: test_restore_device_tracker_save_state[enabled_entities0-vw_id_4-location]
+  list([
+    dict({
+      'raw_value': dict({
+        'latitude': 37.4292,
+        'longitude': 122.1381,
+      }),
+    }),
+  ])
+# ---

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1,0 +1,129 @@
+"""Test device trackers."""
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.restore_state import STORAGE_KEY as RESTORE_STATE_KEY
+import pytest
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_mock_restore_state_shutdown_restart,
+    mock_restore_cache_with_extra_data,
+)
+from syrupy.assertion import SnapshotAssertion
+
+from custom_components.smartcar.const import (
+    DEFAULT_ENABLED_ENTITY_DESCRIPTION_KEYS,
+    EntityDescriptionKey,
+)
+
+from . import setup_added_integration, setup_integration
+
+RESTORE_STATE_PARAMETRIZE_ARGS = [
+    (
+        "entity_id",
+        "stored_data",
+        "device_tracker_state",
+        "coordinator_data",
+    ),
+    [
+        (
+            "device_tracker.vw_id_4_location",
+            {"raw_value": {"latitude": 37.4292, "longitude": 122.1381}},
+            "not_home",
+            {"location": {"latitude": 37.4292, "longitude": 122.1381}},
+        ),
+    ],
+]
+RESTORE_STATE_PARAMETRIZE_IDS = [
+    "location",
+]
+
+
+@pytest.mark.parametrize(
+    *RESTORE_STATE_PARAMETRIZE_ARGS,
+    ids=RESTORE_STATE_PARAMETRIZE_IDS,
+)
+@pytest.mark.usefixtures("enable_specified_entities")
+@pytest.mark.parametrize("vehicle_fixture", ["vw_id_4"])
+@pytest.mark.parametrize(
+    "enabled_entities",
+    [DEFAULT_ENABLED_ENTITY_DESCRIPTION_KEYS | {EntityDescriptionKey.LOCATION}],
+)
+async def test_restore_device_tracker_save_state(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    vehicle_attributes: dict,
+    entity_id: str,
+    stored_data: dict,
+    device_tracker_state: Any,
+    coordinator_data: dict,
+) -> None:
+    """Test saving device tracker/coordinator state."""
+
+    await setup_integration(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["vin"]]
+    coordinator.data = coordinator_data
+
+    await async_mock_restore_state_shutdown_restart(hass)  # trigger saving state
+
+    stored_entity_data = [
+        item["extra_data"]
+        for item in hass_storage[RESTORE_STATE_KEY]["data"]
+        if item["state"]["entity_id"] == entity_id
+    ]
+
+    assert stored_entity_data[0] == stored_data
+    assert stored_entity_data == snapshot
+
+
+@pytest.mark.parametrize(
+    *RESTORE_STATE_PARAMETRIZE_ARGS,
+    ids=RESTORE_STATE_PARAMETRIZE_IDS,
+)
+@pytest.mark.usefixtures("enable_specified_entities")
+@pytest.mark.parametrize("vehicle_fixture", ["vw_id_4"])
+@pytest.mark.parametrize(
+    "enabled_entities",
+    [DEFAULT_ENABLED_ENTITY_DESCRIPTION_KEYS | {EntityDescriptionKey.LOCATION}],
+)
+async def test_restore_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    vehicle_attributes: dict,
+    entity_id: str,
+    stored_data: dict,
+    device_tracker_state: Any,
+    coordinator_data: dict,
+) -> None:
+    """Test device tracker restore state."""
+
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State(
+                    entity_id,
+                    "does-not-matter-for-this-test",
+                ),
+                stored_data,
+            ),
+        ),
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        pref_disable_polling=True,
+    )
+
+    await setup_added_integration(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["vin"]]
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == device_tracker_state
+    assert coordinator.data == coordinator_data


### PR DESCRIPTION
The restore method checks that the entity is not yet available at the time of restore (to avoid clobbering any changed state that happened at startup). But the location's entity description has a value cast that ensures the extracted value is always a dictionary. So testing against the final (casted) value always results in the entity being `available`. Therefore, availability should be based on whether the `raw_value` is non-null.

Resolves: #36