### PR TITLE
Improve availability check

### DIFF
--- a/custom_components/smartcar/entity.py
+++ b/custom_components/smartcar/entity.py
@@ -47,7 +47,11 @@ class SmartcarEntity[ValueT, RawValueT](
 
     @property
     def available(self) -> bool:
-        return super().available and self._extract_raw_value() is not None
+        return (
+            super().available
+            and self._extract_raw_value() is not None
+            and self._extract_value() is not None
+        )
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:


### PR DESCRIPTION
This is a followup to #37 to improve the availability check. In fact, for entities that share coordinator data, i.e. tire pressure, it will be better to ensure that both the raw_value and value are not null. This will ensure that not just the first entity's data data gets restored.