### PR TITLE
Allow a more specific Python to be used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-requires-python = ">=3.13"
+requires-python = ">=3.13,<3.14"
 
 [tool.coverage.run]
 source = [

--- a/script/setup
+++ b/script/setup
@@ -4,17 +4,23 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+PYTHON="python3"
+
+if [ -x "$(command -v python3.13)" ]; then
+  PYTHON="python3.13"
+fi
+
 if [ ! -n "$VIRTUAL_ENV" ]; then
   if [ -x "$(command -v uv)" ]; then
     uv venv venv
   else
-    python3 -m venv venv
+    $PYTHON -m venv venv
   fi
   source venv/bin/activate
 fi
 
 if ! [ -x "$(command -v uv)" ]; then
-  python3 -m pip install uv
+  $PYTHON -m pip install uv
 fi
 
 script/bootstrap


### PR DESCRIPTION
This allows setup to work more easily on Fedora 43 which now includes Python 3.14 by default.