### PR TITLE
Use `charge-detailedchargingstatus` signal for `sensor.<make_model>_charging_status`

### DIFF
--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -54,9 +54,8 @@ class DatapointConfig:
 
     @property
     def storage_key(self) -> str:
-        if self.code:
-            return self.code
-        return f"v2only-{self.storage_key_v2}"
+        assert self.code
+        return self.code
 
     @property
     def storage_key_v2(self) -> str:
@@ -121,7 +120,7 @@ DATAPOINT_ENTITY_KEY_MAP = {
         is_v2_value=_is_v2_value_if_string,  # for saved restore-state values
     ),
     EntityDescriptionKey.CHARGING_STATE: DatapointConfig(
-        None,  # no v3 equivalent
+        "charge-detailedchargingstatus",
         ["read_charge", "control_charge"],
         "/charge",
         "state",

--- a/custom_components/smartcar/sensor.py
+++ b/custom_components/smartcar/sensor.py
@@ -61,7 +61,7 @@ SENSOR_TYPES: tuple[SmartcarSensorDescription, ...] = (
     SmartcarSensorDescription(
         key=EntityDescriptionKey.CHARGING_STATE,
         name="Charging Status",
-        value_key_path="v2only-charge.value",
+        value_key_path="charge-detailedchargingstatus.value",
         icon="mdi:ev-station",
     ),
     SmartcarSensorDescription(

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -12,6 +12,9 @@
             }),
           ]),
         }),
+        'charge-detailedchargingstatus': dict({
+          'value': 'FULLY_CHARGED',
+        }),
         'charge-ischarging': dict({
           'value': False,
         }),
@@ -53,9 +56,6 @@
         }),
         'tractionbattery-stateofcharge': dict({
           'value': 0.3,
-        }),
-        'v2only-charge': dict({
-          'value': 'FULLY_CHARGED',
         }),
         'wheel-tires': dict({
           'columnCount': 2,
@@ -137,6 +137,11 @@
         }),
         'charge-chargelimits:data_age': '2025-05-09T15:40:55+00:00',
         'charge-chargelimits:fetched_at': '2025-05-09T17:27:26.712000+00:00',
+        'charge-detailedchargingstatus': dict({
+          'value': 'NOT_CHARGING',
+        }),
+        'charge-detailedchargingstatus:data_age': '2025-05-09T15:40:57+00:00',
+        'charge-detailedchargingstatus:fetched_at': '2025-05-09T17:27:26.712000+00:00',
         'charge-ischarging': dict({
           'value': False,
         }),
@@ -193,11 +198,6 @@
         'tractionbattery-stateofcharge:data_age': '2025-05-09T15:40:57+00:00',
         'tractionbattery-stateofcharge:fetched_at': '2025-05-09T17:27:26.712000+00:00',
         'tractionbattery-stateofcharge:unit_system': 'metric',
-        'v2only-charge': dict({
-          'value': 'NOT_CHARGING',
-        }),
-        'v2only-charge:data_age': '2025-05-09T15:40:57+00:00',
-        'v2only-charge:fetched_at': '2025-05-09T17:27:26.712000+00:00',
         'wheel-tires': dict({
           'columnCount': 2,
           'rowCount': 2,


### PR DESCRIPTION
This [signal][signal] was either not present or was overlooked when first moving to the v3 API. It is the same info as the [charge status API][v2].

Resolves: #56.

[signal]: https://smartcar.com/docs/api-reference/signals/charge#detailed-charging-status
[v2]: https://smartcar.com/docs/api-reference/evs/get-charge-status