### PR TITLE
Fix tests when run with upgraded dependencies

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
+from . import bootstrap as bootstrap  # noqa: I001, PLC0414
+
 import importlib
 
 from homeassistant.core import HomeAssistant

--- a/tests/bootstrap.py
+++ b/tests/bootstrap.py
@@ -1,0 +1,10 @@
+import sys
+
+from . import mock_cloud
+
+ha_cloud_module = type(sys)("cloud")
+sys.modules["homeassistant.components.cloud"] = ha_cloud_module
+
+for key in mock_cloud.__dict__:
+    if not key.startswith("_"):
+        setattr(ha_cloud_module, key, getattr(mock_cloud, key))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 """Fixtures for testing."""
 
+from . import bootstrap as bootstrap  # noqa: I001, PLC0414
+
 from collections.abc import Generator
 import logging
 import time

--- a/tests/mock_cloud.py
+++ b/tests/mock_cloud.py
@@ -1,0 +1,28 @@
+"""Mock implementation of homeassistant.components.cloud.
+
+This avoids having to import the module and all of its dependencies which would
+create a large dependency tree including modules that fail to import in certain
+environments.
+"""
+
+from homeassistant.core import HomeAssistant
+
+
+def async_active_subscription(hass: HomeAssistant) -> bool:
+    return False
+
+
+async def async_delete_cloudhook(hass: HomeAssistant, webhook_id: str) -> None:  # noqa: RUF029
+    raise CloudNotAvailable
+
+
+async def async_get_or_create_cloudhook(hass: HomeAssistant, webhook_id: str) -> str:  # noqa: RUF029
+    raise CloudNotConnected
+
+
+class CloudNotAvailable(Exception):
+    pass
+
+
+class CloudNotConnected(Exception):
+    pass


### PR DESCRIPTION
On of November Nov 17, 2025, the test suite started failing in the GitHub CI environment when run with dependencies upgraded. The scheduled run from the day before was successful, and there were no dependency changes that appear to point to the newly occurring import error (see below). Perhaps something changed in the container/run environment.

Regardless, there's no need to actually import the dependency tree that's being imported for the `cloud` component when most of the tests are mocking the functions anyway.

The import error is:

```
ImportError while loading conftest '/home/runner/work/Smartcar-HA/Smartcar-HA/tests/conftest.py'.
tests/__init__.py:10: in <module>
    from custom_components.smartcar.const import DOMAIN
custom_components/smartcar/__init__.py:8: in <module>
    from homeassistant.components import cloud, webhook
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/homeassistant/components/cloud/__init__.py:16: in <module>
    from homeassistant.components import alexa, google_assistant
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/homeassistant/components/alexa/__init__.py:20: in <module>
    from . import flash_briefings, intent, smart_home
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/homeassistant/components/alexa/smart_home.py:22: in <module>
    from .config import AbstractConfig
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/homeassistant/components/alexa/config.py:16: in <module>
    from .entities import TRANSLATION_TABLE
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/homeassistant/components/alexa/entities.py:9: in <module>
    from homeassistant.components import (
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/homeassistant/components/camera/__init__.py:77: in <module>
    from .img_util import (
/opt/hostedtoolcache/Python/3.13.11/x64/lib/python3.13/site-packages/homeassistant/components/camera/img_util.py:8: in <module>
    from turbojpeg import TurboJPEG
E   ModuleNotFoundError: No module named 'turbojpeg'
```