### PR TITLE
Ensure failed service calls raise an exception

### DIFF
--- a/custom_components/smartcar/entity.py
+++ b/custom_components/smartcar/entity.py
@@ -19,6 +19,7 @@ from homeassistant.util import dt as dt_util
 from . import const as smartcar_const
 from .const import DOMAIN
 from .coordinator import SmartcarVehicleCoordinator
+from .types import SmartcarAPIError
 from .util import key_path_get
 
 _LOGGER = logging.getLogger(__name__)
@@ -157,9 +158,12 @@ class SmartcarEntity[ValueT, RawValueT](
         version: str = "2.0",
         **kwargs,  # noqa: ARG002, ANN003
     ) -> bool:
-        return await async_send_command(
-            self.coordinator, subpath, payload, method=method, version=version
-        )
+        try:
+            return await async_send_command(
+                self.coordinator, subpath, payload, method=method, version=version
+            )
+        except SmartcarAPIError:
+            return False
 
 
 class IndirectDescriptorDefaultType(Enum):
@@ -284,7 +288,7 @@ async def async_send_command(
             ERROR_STATUS_COMPATIBILITY,
             ERROR_STATUS_UPSTREAM,
         }:
-            pass
+            raise SmartcarAPIError(err.status, err.message) from err
         else:
             raise
 

--- a/custom_components/smartcar/types.py
+++ b/custom_components/smartcar/types.py
@@ -17,3 +17,11 @@ class SmartcarData:
 
     auth: AbstractAuth
     coordinators: dict[str, SmartcarVehicleCoordinator]
+
+
+@dataclass
+class SmartcarAPIError(Exception):
+    """Error representing an issue via the Smartcar API."""
+
+    code: int
+    reason: str

--- a/tests/snapshots/test_services.ambr
+++ b/tests/snapshots/test_services.ambr
@@ -3,6 +3,9 @@
   list([
   ])
 # ---
+# name: test_door_closure[invalid_config_entry-unknown_make][error]
+  ServiceValidationError('invalid_config_entry')
+# ---
 # name: test_door_closure[lock_doors-unknown_make][api-calls]
   list([
     tuple(
@@ -58,4 +61,10 @@
       }),
     ),
   ])
+# ---
+# name: test_door_closure[unreachable-unknown_make][error]
+  dict({
+    'code': 409,
+    'reason': '',
+  })
 # ---

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -20,6 +20,7 @@ from custom_components.smartcar.services import (
     SERVICE_NAME_LOCK_DOORS,
     SERVICE_NAME_UNLOCK_DOORS,
 )
+from custom_components.smartcar.types import SmartcarAPIError
 
 from . import MOCK_API_ENDPOINT, setup_added_integration
 
@@ -60,6 +61,7 @@ def test_has_services(
             "status": 409,
             "status_slug": "unreachable",
             "expected_state": STATE_UNAVAILABLE,
+            "expected_raises": SmartcarAPIError,
             "expected_api_calls": 1,
         },
         {
@@ -143,3 +145,6 @@ async def test_door_closure(
     assert [tuple(mock_call) for mock_call in aioclient_mock.mock_calls] == snapshot(
         name="api-calls"
     )
+
+    if expected_raises != NO_ERROR:
+        assert raised_error == snapshot(name="error")


### PR DESCRIPTION
This is a followup to #64 that ensures an error is raised if the API call fails, an important issue brought about from [further discussion on the original issue](https://github.com/tube0013/Smartcar-HA/issues/61#issuecomment-3706314094).