### PR TITLE
Use more specific HTTP status codes for webhook responses

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,8 +355,8 @@ def webhook_scenario(
         )
 
         expected_calls = 0
-        expected_response = expected.get("response", {})
-        expected_response_status = expected.get("response_status", 200)
+        expected_response = expected.get("response", "")
+        expected_response_status = expected.get("response_status", 204)
         expected_reauth_calls = expected.get("reauth_calls", 0)
         expected_log_messages = expected.get("log_messages", [])
 
@@ -381,7 +381,11 @@ def webhook_scenario(
             )
             assert resp.status == expected_response_status
             assert (
-                await (resp.json() if expected_response_status < 300 else resp.text())
+                await (
+                    resp.json()
+                    if resp.content_type == "application/json"
+                    else resp.text()
+                )
                 == expected_response
             )
             await hass.async_block_till_done()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -164,9 +164,10 @@ async def test_update_with_polling_disabled(
             "verify",  # JSON fixture
             {},
             {
+                "response_status": 200,
                 "response": {
                     "challenge": "1234",  # from mock_hmac_sha256_hexdigest
-                }
+                },
             },
         ),
         (
@@ -193,8 +194,13 @@ async def test_update_with_polling_disabled(
                 "sc-signature": "1234",
             },
             {
-                "response_status": 404,
-                "response": "",
+                "response_status": 409,
+                "response": {
+                    "error": {
+                        "code": "unknown_vehicle",
+                        "message": "unknown vehicle included",
+                    }
+                },
                 "log_messages": [
                     "unknown vehicle with id: 70076e4a-d774-464c-8241-60de654ccb24, vin: unknown"
                 ],
@@ -235,14 +241,25 @@ async def test_update_with_polling_disabled(
             {
                 "sc-signature": "1234",
             },
-            {"log_messages": ["invalid JSON"]},
+            {
+                "response_status": 400,
+                "response": {
+                    "error": {"code": "invalid_json", "message": "invalid JSON body"}
+                },
+                "log_messages": ["invalid JSON"],
+            },
         ),
         (
             {},
             {"sc-signature": "invalid-4321"},
             {
-                "response_status": 404,
-                "response": "",
+                "response_status": 401,
+                "response": {
+                    "error": {
+                        "code": "invalid_signature",
+                        "message": "invalid signature on request body",
+                    }
+                },
                 "log_messages": ["invalid signature"],
             },
         ),


### PR DESCRIPTION
Also, send back a little JSON message with some codes to possibly further aid in debugging.

Resolves: #84