### PR TITLE
Enable polling alongside webhooks

### DIFF
--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.util import dt as dt_util
 
 from .auth import AbstractAuth
-from .const import CONF_APPLICATION_MANAGEMENT_TOKEN, DOMAIN, EntityDescriptionKey
+from .const import DOMAIN, EntityDescriptionKey
 from .util import key_path_get, key_path_update
 
 _LOGGER = logging.getLogger(__name__)
@@ -514,9 +514,7 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=f"{DOMAIN}_{vin}",
-            update_interval=UPDATE_INTERVAL
-            if CONF_APPLICATION_MANAGEMENT_TOKEN not in entry.data
-            else None,
+            update_interval=UPDATE_INTERVAL,
         )
 
     def is_scope_enabled(
@@ -571,10 +569,7 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
         """
         if self.batch_requests:
             return
-        if (
-            self.config_entry.pref_disable_polling
-            or CONF_APPLICATION_MANAGEMENT_TOKEN in self.config_entry.data
-        ):
+        if self.config_entry.pref_disable_polling:
             return
 
         entities: list[er.RegistryEntry] = er.async_entries_for_config_entry(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -374,7 +374,6 @@ def webhook_scenario(
             },
         )
 
-        expected_calls = 0
         expected_response = expected.get("response", "")
         expected_response_status = expected.get("response_status", 204)
         expected_reauth_calls = expected.get("reauth_calls", 0)
@@ -383,9 +382,8 @@ def webhook_scenario(
         with patch("custom_components.smartcar.PLATFORMS", [platform]):
             await setup_added_integration(hass, mock_config_entry)
 
-        # no requests should have been made during setup when webhooks are enabled
-        # because this automatically disables polling.
-        assert aioclient_mock.call_count == expected_calls
+        # polling occurs during setup even when webhooks are enabled
+        calls_after_setup = aioclient_mock.call_count
 
         with patch(
             "homeassistant.config_entries.ConfigEntry.async_start_reauth"
@@ -410,8 +408,8 @@ def webhook_scenario(
             )
             await hass.async_block_till_done()
 
-        # still no calls since webhooks will update from the data it received
-        assert aioclient_mock.call_count == expected_calls
+        # no additional calls since webhooks update from the data they received
+        assert aioclient_mock.call_count == calls_after_setup
         assert mock_start_reauth.call_count == expected_reauth_calls
 
         device_id = vehicle_attributes["vin"]


### PR DESCRIPTION
## Summary
- Polling now runs on the standard 6-hour interval even when webhooks are configured, providing a fallback when webhooks aren't delivering data
- Previously, configuring an application management token completely disabled polling, leaving sensors unavailable if webhooks failed
- Removed the two gates in the coordinator that prevented polling when webhooks were enabled

## Test plan
- [ ] Verify webhook scenario tests pass with updated call count assertions
- [ ] Verify polling-only tests pass unchanged
- [ ] Verify `pref_disable_polling=True` tests still pass (untouched path)
- [ ] Test with webhooks configured: confirm sensors populate via polling on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)